### PR TITLE
Fix space in \ie and \eg macros

### DIFF
--- a/macros.tex
+++ b/macros.tex
@@ -28,8 +28,8 @@
 \newcommand{\emb}{\hookrightarrow}
 \newcommand{\embed}[2]{\phi_{#1\hookrightarrow#2}}
 \newcommand{\ent}[2]{[\![#1,#2]\!]}
-\newcommand{\ie}{\emph{i.e. }}
-\newcommand{\etal}{\emph{et al. }}
+\newcommand{\ie}{\emph{i.e.\ }}
+\newcommand{\etal}{\emph{et al.\ }}
 \newcommand{\ps}[2]{\left\langle#1,#2\right\rangle}
 \newcommand{\eqdef}{\overset{\text{def}}{=}}
 \newcommand{\f}{f}%{\mathfrak{f}}


### PR DESCRIPTION
Following english typographic conventions, Latex inserts a double
space after a stop (.). However, this is inappropriate after an
initialism such as i.e. or e.g., and must be fixed by adding `\ `
after the stop.